### PR TITLE
Bug Fix Infinite Loop

### DIFF
--- a/ADB Explorer/Services/AppInfra/CopyPasteService.cs
+++ b/ADB Explorer/Services/AppInfra/CopyPasteService.cs
@@ -421,7 +421,7 @@ public class CopyPasteService : ViewModelBase
             }
             else if (result.Item1 is ContentDialogResult.Secondary) // Skip
             {
-                fileNames = fileNames.Where(item => !existingItems.Contains(FileHelper.GetFullName(item)));
+                fileNames = fileNames.Where(item => !existingItems.Any(existing => FileHelper.GetFullName(existing).Equals(FileHelper.GetFullName(item), comparisonType))).ToList();
             }
         }
         

--- a/ADB Explorer/Services/AppInfra/CopyPasteService.cs
+++ b/ADB Explorer/Services/AppInfra/CopyPasteService.cs
@@ -396,8 +396,8 @@ public class CopyPasteService : ViewModelBase
         {
             var files = Directory.GetFiles(targetPath);
             var dirs = Directory.GetDirectories(targetPath);
-
-            existingItems = dirs.Concat(files).Where(f => fileNames.Any(name => FileHelper.GetFullName(name).Equals(FileHelper.GetFullName(f), comparisonType)));
+            var fileNamesFullPaths = new HashSet<string>(fileNames.Select(name => FileHelper.GetFullName(name)),   StringComparer.InvariantCultureIgnoreCase); // Case-insensitive comparison
+            existingItems = dirs.Concat(files).Where(f => fileNamesFullPaths.Contains(FileHelper.GetFullName(f))).ToList();
         }
 
         var count = existingItems.Count();
@@ -421,7 +421,13 @@ public class CopyPasteService : ViewModelBase
             }
             else if (result.Item1 is ContentDialogResult.Secondary) // Skip
             {
-                fileNames = fileNames.Where(item => !existingItems.Any(existing => FileHelper.GetFullName(existing).Equals(FileHelper.GetFullName(item), comparisonType))).ToList();
+                // Create a HashSet of full names from existingItems for fast lookup
+                var existingFullNames = new HashSet<string>(
+                    existingItems.Select(existing => FileHelper.GetFullName(existing)),
+                    StringComparer.InvariantCultureIgnoreCase); // Case-insensitive comparison
+                fileNames = fileNames
+                    .Where(item => !existingFullNames.Contains(FileHelper.GetFullName(item)))
+                    .ToList();
             }
         }
         

--- a/ADB Explorer/Services/AppInfra/CopyPasteService.cs
+++ b/ADB Explorer/Services/AppInfra/CopyPasteService.cs
@@ -370,6 +370,27 @@ public class CopyPasteService : ViewModelBase
                   cutType: cutType);
     }
 
+   public static StringComparer GetStringComparer(StringComparison comparison)
+    {
+        switch (comparison)
+        {
+            case StringComparison.Ordinal:
+                return StringComparer.Ordinal;
+            case StringComparison.OrdinalIgnoreCase:
+                return StringComparer.OrdinalIgnoreCase;
+            case StringComparison.InvariantCulture:
+                return StringComparer.InvariantCulture;
+            case StringComparison.InvariantCultureIgnoreCase:
+                return StringComparer.InvariantCultureIgnoreCase;
+            case StringComparison.CurrentCulture:
+                return StringComparer.CurrentCulture;
+            case StringComparison.CurrentCultureIgnoreCase:
+                return StringComparer.CurrentCultureIgnoreCase;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(comparison), comparison, null);
+        }
+    }
+
     public static async Task<IEnumerable<string>> MergeFiles(IEnumerable<string> fileNames, string targetPath)
     {
         IEnumerable<string> existingItems = [];
@@ -396,7 +417,7 @@ public class CopyPasteService : ViewModelBase
         {
             var files = Directory.GetFiles(targetPath);
             var dirs = Directory.GetDirectories(targetPath);
-            var fileNamesFullPaths = new HashSet<string>(fileNames.Select(name => FileHelper.GetFullName(name)),   StringComparer.InvariantCultureIgnoreCase); // Case-insensitive comparison
+            var fileNamesFullPaths = new HashSet<string>(fileNames.Select(name => FileHelper.GetFullName(name)), GetStringComparer(comparisonType)); // Case-insensitive comparison
             existingItems = dirs.Concat(files).Where(f => fileNamesFullPaths.Contains(FileHelper.GetFullName(f))).ToList();
         }
 
@@ -424,7 +445,7 @@ public class CopyPasteService : ViewModelBase
                 // Create a HashSet of full names from existingItems for fast lookup
                 var existingFullNames = new HashSet<string>(
                     existingItems.Select(existing => FileHelper.GetFullName(existing)),
-                    StringComparer.InvariantCultureIgnoreCase); // Case-insensitive comparison
+                    GetStringComparer(comparisonType));
                 fileNames = fileNames
                     .Where(item => !existingFullNames.Contains(FileHelper.GetFullName(item)))
                     .ToList();

--- a/ADB Explorer/Services/AppInfra/FileAction/FileActionLogic.cs
+++ b/ADB Explorer/Services/AppInfra/FileAction/FileActionLogic.cs
@@ -863,7 +863,7 @@ internal static class FileActionLogic
         var files = await CopyPasteService.MergeFiles(pullItems.Select(f => f.FullPath), path.ParsingName);
         if (files.Count() < pullItems.Count())
         {
-            pullItems = pullItems.Where(f => files.Contains(f.FullName));
+            pullItems = pullItems.Where(f => files.Contains(f.FullPath));
         }
 
         foreach (var item in pullItems)

--- a/ADB Explorer/Services/AppInfra/LowLevel/DiskUsage.cs
+++ b/ADB Explorer/Services/AppInfra/LowLevel/DiskUsage.cs
@@ -10,7 +10,20 @@ public class DiskUsage : ViewModelBase
 
     public Process Process { get; }
 
-    public int? PID => Process?.Id;
+    public int? PID
+    {
+        get
+        {
+            try
+            {
+                return Process?.Id;
+            }
+            catch (InvalidOperationException)
+            {
+                return null;
+            }
+        }
+    }
 
     private ulong? readRate;
     public ulong? ReadRate
@@ -155,8 +168,18 @@ internal static class DiskUsageHelper
         {
             if (usage is null || usage.Process is null)
                 continue;
+            try
+            {
+                var matchingProcess = newUsages.FirstOrDefault(proc => proc.PID == usage.PID);
 
-            usage.Update(newUsages.FirstOrDefault(proc => proc.PID == usage.PID));
+                if (matchingProcess != null)
+                {
+                    usage.Update(matchingProcess);
+                }
+            }
+            catch (InvalidOperationException)
+            {
+            }
         }
 
         var newUsage = DiskUsage.Consolidate(newUsages);


### PR DESCRIPTION
Bug fix for infinite loop on existing filenames when using skip by adding .ToList() to make it execute immediately and not update the variable until complete.
Modified linq code to run quicker was freezing when attempting to copy 1500 files from phone to pc, with updated query I seen no hesitation.
