### PR TITLE
Fixes for rooted devices, UI freeze & assorted bugs

### DIFF
--- a/ADB Explorer/App.xaml.cs
+++ b/ADB Explorer/App.xaml.cs
@@ -161,10 +161,17 @@ public partial class App
         AppCulture.ApplyThreadCultures();
 
 #if !DEPLOY
-        if (!File.Exists(ADB_Explorer.Properties.AppGlobal.DragDropLogPath))
+        // the drag-drop log dir only exists on a dev machine; don't let it block startup
+        try
         {
-            File.WriteAllText(ADB_Explorer.Properties.AppGlobal.DragDropLogPath, "");
+            if (Directory.Exists(Path.GetDirectoryName(ADB_Explorer.Properties.AppGlobal.DragDropLogPath))
+                && !File.Exists(ADB_Explorer.Properties.AppGlobal.DragDropLogPath))
+            {
+                File.WriteAllText(ADB_Explorer.Properties.AppGlobal.DragDropLogPath, "");
+            }
         }
+        catch (SystemException)
+        { }
 #endif
 
         ClearFoldersInAppData();

--- a/ADB Explorer/Controls/NavigationBox.xaml.cs
+++ b/ADB Explorer/Controls/NavigationBox.xaml.cs
@@ -470,7 +470,10 @@ public partial class NavigationBox : UserControl
 
     private void ApplyDriveRestrictions()
     {
-        var driveRestrictions = _trackedDrive?.Restrictions ?? DriveRestrictions.None;
+        // resolve per-path: on the root drive, sub-mounts (rw /data under ro /) differ from the drive
+        var driveRestrictions = string.IsNullOrEmpty(Path)
+            ? _trackedDrive?.Restrictions ?? DriveRestrictions.None
+            : DriveHelper.GetPathRestrictions(Path);
         var deviceId = Data.DevicesObject?.Current?.ID;
         var isArchive = ArchivePath.IsArchivePath(Path, deviceId);
 
@@ -489,7 +492,7 @@ public partial class NavigationBox : UserControl
         }
         else
         {
-            tooltipText = _trackedDrive?.RestrictionsTooltip ?? "";
+            tooltipText = driveRestrictions.GetTooltipText();
             iconGlyph = driveRestrictions.IconGlyph;
             HasDriveRestrictions = driveRestrictions.HasAny;
         }

--- a/ADB Explorer/Controls/Pages/DevicesPageHeader.xaml
+++ b/ADB Explorer/Controls/Pages/DevicesPageHeader.xaml
@@ -140,7 +140,21 @@
                     Click="RefreshDevicesButton_Click"
                     Style="{StaticResource DevicesManualPollingButtonStyle}"
                     ToolTip="{Binding Source={x:Static Member=strings:Resources.S_REFRESH_DEVICES}}">
-                    <ui:FontIcon FontSize="15" Glyph="&#xE72C;" />
+                    <Grid
+                        Width="22"
+                        Height="22"
+                        ClipToBounds="False">
+                        <ui:FontIcon
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            FontSize="15"
+                            Glyph="&#xE72C;"
+                            RenderTransformOrigin="0.5,0.5">
+                            <ui:FontIcon.RenderTransform>
+                                <RotateTransform x:Name="RefreshIconRotate" />
+                            </ui:FontIcon.RenderTransform>
+                        </ui:FontIcon>
+                    </Grid>
                 </Button>
             </Grid>
             <TextBlock

--- a/ADB Explorer/Controls/Pages/DevicesPageHeader.xaml.cs
+++ b/ADB Explorer/Controls/Pages/DevicesPageHeader.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using ADB_Explorer.Helpers;
 using ADB_Explorer.Models;
 using ADB_Explorer.Services;
+using System.Windows.Media.Animation;
 
 namespace ADB_Explorer.Controls.Pages;
 
@@ -46,9 +47,59 @@ public partial class DevicesPageHeader : UserControl
         }
     }
 
-    private void RefreshDevicesButton_Click(object sender, RoutedEventArgs e)
+    private bool _isRefreshing;
+
+    private async void RefreshDevicesButton_Click(object sender, RoutedEventArgs e)
     {
-        DevicePollingService.RefreshDevices(CancellationToken.None);
+        // Ignore clicks while a refresh is already running - no point spawning concurrent scans.
+        if (_isRefreshing)
+            return;
+
+        _isRefreshing = true;
+        StartRefreshSpin();
+
+        var startTick = Environment.TickCount64;
+
+        try
+        {
+            // RefreshDevices makes several blocking adb calls (device list, per-device whoami/id, mDNS scan),
+            // so run it off the UI thread - same as the polling loop does - to keep the app responsive.
+            // A blocking adb call can throw; this is an async void handler, so an escaping exception would
+            // crash the app and leave the button/spinner stuck - hence the try/finally.
+            await Task.Run(() => DevicePollingService.RefreshDevices(CancellationToken.None));
+
+            // Keep the spinner visible for a moment even on a fast refresh, so the click clearly registers.
+            var elapsed = Environment.TickCount64 - startTick;
+            if (elapsed < 500)
+                await Task.Delay((int)(500 - elapsed));
+        }
+        catch
+        {
+            // A failed manual refresh shouldn't take the app down; the next poll will recover the device list.
+        }
+        finally
+        {
+            StopRefreshSpin();
+            _isRefreshing = false;
+        }
+    }
+
+    private void StartRefreshSpin()
+    {
+        var spin = new DoubleAnimation
+        {
+            From = 0,
+            To = 360,
+            Duration = TimeSpan.FromSeconds(1),
+            RepeatBehavior = RepeatBehavior.Forever,
+        };
+        RefreshIconRotate.BeginAnimation(RotateTransform.AngleProperty, spin);
+    }
+
+    private void StopRefreshSpin()
+    {
+        RefreshIconRotate.BeginAnimation(RotateTransform.AngleProperty, null);
+        RefreshIconRotate.Angle = 0;
     }
 
     private void UIList_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/ADB Explorer/Controls/Pages/ExplorerPageHeader.xaml
+++ b/ADB Explorer/Controls/Pages/ExplorerPageHeader.xaml
@@ -127,6 +127,7 @@
                     <local:SearchBox
                         x:Name="SearchBox"
                         Grid.Column="2"
+                        Committed="SearchBox_Committed"
                         IsExpanded="{Binding Source={x:Static Member=models:Data.RuntimeSettings}, Path=IsSearchBoxFocused, Mode=TwoWay}"
                         Style="{StaticResource SearchBoxStyle}" />
                 </Grid>
@@ -403,6 +404,20 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
+                            <DataGridTextColumn
+                                x:Name="SearchLocation"
+                                Width="240"
+                                Binding="{Binding ParentPath}"
+                                FontSize="{Binding Source={StaticResource FontSize}}"
+                                Header="{Binding Source={x:Static Member=strings:Resources.S_COLUMN_LOCATION}}"
+                                IsReadOnly="True"
+                                Visibility="{Binding Source={StaticResource ViewModelProxy}, Path=Data.SearchColumnVisibility}">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style BasedOn="{StaticResource DirectoryGridCellStyle}" TargetType="TextBlock">
+                                        <Setter Property="FlowDirection" Value="LeftToRight" />
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
                             <DataGridTextColumn
                                 x:Name="OriginalPath"
                                 Width="180"

--- a/ADB Explorer/Controls/Pages/ExplorerPageHeader.xaml.cs
+++ b/ADB Explorer/Controls/Pages/ExplorerPageHeader.xaml.cs
@@ -688,6 +688,7 @@ public partial class ExplorerPageHeader : UserControl
 
         FileActions.WasInAppDrive = FileActions.IsAppDrive;
         FileActions.ExplorerFilter = "";
+        FileActions.IsExplorerSearchResults = false;
         NavHistory.Navigate(realPath);
 
         ViewModel.FirstSelectedIndex = -1;
@@ -760,6 +761,41 @@ public partial class ExplorerPageHeader : UserControl
         FileActionLogic.UpdateFileActions();
 
         return true;
+    }
+
+    private void SearchBox_Committed(object sender, RoutedEventArgs e)
+    {
+        var query = FileActions.ExplorerFilter;
+
+        if (!FileActions.IsExplorerVisible
+            || FileActions.IsRecycleBin
+            || FileActions.IsAppDrive
+            || FileActions.IsArchive
+            || DirList is null
+            || string.IsNullOrEmpty(CurrentPath))
+        {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(query))
+        {
+            // empty commit (Enter on a blank box, or Escape) leaves search and restores the listing
+            if (FileActions.IsExplorerSearchResults)
+            {
+                FileActions.IsExplorerSearchResults = false;
+                FileActionLogic.Refresh();
+            }
+
+            return;
+        }
+
+        FileActions.IsExplorerSearchResults = true;
+
+        ViewModel.FirstSelectedIndex = -1;
+        ViewModel.CurrentSelectedIndex = -1;
+        ActiveUnselectAll();
+
+        DirList.NavigateToSearch(CurrentPath, query);
     }
 
     private void SortExplorer()
@@ -1624,7 +1660,15 @@ public partial class ExplorerPageHeader : UserControl
     private void NameColumnEdit_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
     {
         if (e.NewValue is not true)
+        {
+            // The edit box was hidden for any reason (clean commit, but also a list refresh, row recycling,
+            // or an interrupted rename). Clear the editing flag so the rename tooltip, bound to it, can't
+            // stay stuck on screen.
+            if (FileActions.IsExplorerEditing)
+                FileActions.IsExplorerEditing = false;
+
             return;
+        }
 
         var textBox = sender as TextBox;
 

--- a/ADB Explorer/Controls/SearchBox.xaml.cs
+++ b/ADB Explorer/Controls/SearchBox.xaml.cs
@@ -136,12 +136,21 @@ public partial class SearchBox : UserControl
             ContentBox.Width = MinControlWidth;
     }
 
+    /// <summary>Raised on Enter (commit) or Escape (clear).</summary>
+    public event RoutedEventHandler? Committed;
+
     private void ContentBox_KeyDown(object sender, KeyEventArgs e)
     {
         if (e.Key is Key.Escape)
         {
             Text = "";
             Unfocus();
+            Committed?.Invoke(this, new RoutedEventArgs());
+        }
+        else if (e.Key is Key.Enter)
+        {
+            Committed?.Invoke(this, new RoutedEventArgs());
+            e.Handled = true;
         }
     }
 

--- a/ADB Explorer/Helpers/AdbHelper.cs
+++ b/ADB Explorer/Helpers/AdbHelper.cs
@@ -317,7 +317,14 @@ public static class AdbHelper
 
     public static void ApplyMountInfo(LogicalDeviceViewModel device, CancellationToken cancellationToken)
     {
-        var infos = GetMountInfo(device, cancellationToken);
+        var infos = GetMountInfo(device, cancellationToken).ToList();
+
+        // a cancelled fetch is truncated; don't overwrite a good table with it
+        if (cancellationToken.IsCancellationRequested)
+            return;
+
+        if (infos.Count > 0)
+            device.MountPoints = infos;
 
         foreach (var drive in device.Drives.OfType<LogicalDriveViewModel>())
         {
@@ -366,7 +373,12 @@ public static class AdbHelper
             App.SafeInvoke(() => drive.FSInfo = info);
         }
 
-        App.SafeInvoke(FileActionLogic.UpdateFileActions);
+        App.SafeInvoke(() =>
+        {
+            // recompute access; the first pass may have run before the mount table arrived
+            Data.DirList?.RefreshLocationAccess();
+            FileActionLogic.UpdateFileActions();
+        });
     }
 
     private static IEnumerable<Models.FileSystemInfo> GetMountInfo(LogicalDeviceViewModel device, CancellationToken cancellationToken)

--- a/ADB Explorer/Helpers/DeviceHelper.cs
+++ b/ADB Explorer/Helpers/DeviceHelper.cs
@@ -711,14 +711,20 @@ public static class DeviceHelper
             if (device is null)
                 return false;
 
-            while (device.Status is not DeviceStatus.Ok)
+            // Also wait for the capability probe (ShellCommands.FindCommands populates DeviceCommands) to finish
+            // before auto-opening. Opening while that probe is still running races the device setup and freezes
+            // the UI - a manual "Browse" click works precisely because by then the probe is already done.
+            while (device.Status is not DeviceStatus.Ok
+                   || !ShellCommands.DeviceCommands.ContainsKey(device.ID))
             {
                 if (DateTime.Now - startTime > TimeSpan.FromSeconds(6))
-                    return false;
+                    break;
 
                 Thread.Sleep(500);
             }
-            return true;
+
+            // Proceed once the device is usable, even if the capability probe was slow to register.
+            return device.Status is DeviceStatus.Ok;
         }).ContinueWith(t => App.SafeInvoke(() =>
         {
             if (!t.Result)
@@ -731,48 +737,67 @@ public static class DeviceHelper
     public static async void InitDevice()
     {
         var device = Data.DevicesObject.Current;
-        device.EnsureDefaultDrives();
-        var internalDrive = device.Drives.First(d => d.Type is AbstractDrive.DriveType.Internal).Drive as LogicalDrive;
 
-        // Run both ADB calls concurrently on background threads instead of blocking the UI thread.
-        // Props (getprop) is needed by CombineDisplayNames (BrandName) and SetAndroidVersion.
-        // AdbFeatures is needed for sync/list size capability checks.
-        // GetInternalStorage (readlink) is independent and updates the internal drive path.
-        var propsTask = Task.Run(() => device.Props);
-        var featuresTask = Task.Run(() => device.AdbFeatures);
-        var shellTask = Task.Run(() => device.GetOrLoadShellIdentity());
+        // Pause the periodic polling while we set the device up. Otherwise the poll (device list, root re-check,
+        // IP, drive counts) hammers the same device concurrently with this setup and all their UI updates land on
+        // the UI thread together - that's the "everything fires at once" freeze on connect. Guaranteed to resume.
+        DevicePollingService.IsDeviceSetupInProgress = true;
+        try
+        {
+            device.EnsureDefaultDrives();
+            var internalDrive = device.Drives.First(d => d.Type is AbstractDrive.DriveType.Internal).Drive as LogicalDrive;
 
-        internalDrive.UpdateInternalStorage(device.ID);
+            // Run both ADB calls concurrently on background threads instead of blocking the UI thread.
+            // Props (getprop) is needed by CombineDisplayNames (BrandName) and SetAndroidVersion.
+            // AdbFeatures is needed for sync/list size capability checks.
+            // GetInternalStorage (readlink) is independent and updates the internal drive path.
+            var propsTask = Task.Run(() => device.Props);
+            var featuresTask = Task.Run(() => device.AdbFeatures);
+            var shellTask = Task.Run(() => device.GetOrLoadShellIdentity());
 
-        // Start drive enumeration and battery update immediately — both are independent of Props
-        FileActionLogic.RefreshDrives(true, CancellationToken.None);
-        Task.Run(() => device.UpdateBattery(CancellationToken.None));
+            internalDrive.UpdateInternalStorage(device.ID);
 
-        // Suspend until Props is loaded without blocking the UI thread.
-        // CombineDisplayNames and DriveViewNav must run after Props so that
-        // BrandName and CurrentDisplayNames are populated before breadcrumbs render.
-        await propsTask;
-        await featuresTask;
-        await shellTask;
+            // Start drive enumeration and battery update immediately — both are independent of Props
+            FileActionLogic.RefreshDrives(true, CancellationToken.None);
+            Task.Run(() => device.UpdateBattery(CancellationToken.None));
 
-        if (Data.DevicesObject.Current != device)
-            return;
+            // Suspend until Props is loaded without blocking the UI thread.
+            // CombineDisplayNames and DriveViewNav must run after Props so that
+            // BrandName and CurrentDisplayNames are populated before breadcrumbs render.
+            await propsTask;
+            await featuresTask;
+            await shellTask;
 
-        device.SetAndroidVersion();
-        FolderHelper.CombineDisplayNames();
-        Data.RuntimeSettings.DriveViewNav = true;
-        NavHistory.Navigate(Navigation.SpecialLocation.DriveView);
+            if (Data.DevicesObject.Current != device)
+                return;
 
-        if (Data.Settings.ThumbsMode is AppSettings.ThumbnailMode.OnConnect)
-            Task.Run(() => ThumbnailService.ForceLoad(device));
+            device.SetAndroidVersion();
+            FolderHelper.CombineDisplayNames();
+            Data.RuntimeSettings.DriveViewNav = true;
+            NavHistory.Navigate(Navigation.SpecialLocation.DriveView);
 
-        Data.CopyPaste.GetClipboardPasteItems();
-        Data.RuntimeSettings.FilterDrives = true;
+            if (Data.Settings.ThumbsMode is AppSettings.ThumbnailMode.OnConnect)
+                Task.Run(() => ThumbnailService.ForceLoad(device));
 
-        Data.FileActions.PushPackageEnabled = Data.Settings.EnableApk && device?.Type is not DeviceType.Recovery;
+            Data.CopyPaste.GetClipboardPasteItems();
+            Data.RuntimeSettings.FilterDrives = true;
 
-        Data.FileOpQ.MoveOperationsToPast();
-        FileActionLogic.UpdateFileActions();
+            Data.FileActions.PushPackageEnabled = Data.Settings.EnableApk && device?.Type is not DeviceType.Recovery;
+
+            Data.FileOpQ.MoveOperationsToPast();
+            FileActionLogic.UpdateFileActions();
+
+            // Setup is complete: now it's safe to auto-root. Enabling root restarts adbd, so doing it earlier
+            // (on connect) collides with the setup above. Gate on the ACTUAL shell identity (already loaded above),
+            // not just the Root flag: after the restart the device reconnects and re-runs this setup, and the VM
+            // can come back "Unchecked" - but the shell is now root, so !HasRootShell stops a second fire/restart.
+            if (Data.Settings.AutoRoot && device.Root is RootStatus.Unchecked && !device.HasRootShell)
+                _ = Task.Run(() => device.EnableRoot(true));
+        }
+        finally
+        {
+            DevicePollingService.IsDeviceSetupInProgress = false;
+        }
     }
 
     #region Test device injection (DEBUG only)

--- a/ADB Explorer/Helpers/DriveHelper.cs
+++ b/ADB Explorer/Helpers/DriveHelper.cs
@@ -40,9 +40,51 @@ internal class DriveHelper
         return drive.Type is AbstractDrive.DriveType.Internal && AdbExplorerConst.IsInternalStoragePath(path);
     }
 
+    /// <summary>
+    /// Restrictions of the mount a path sits on. The root drive spans several mounts (/ is ro, /data is rw),
+    /// so paths under it are matched against the device mount table by longest prefix.
+    /// </summary>
+    public static DriveRestrictions GetPathRestrictions(string path)
+    {
+        var drive = GetCurrentDrive(path);
+
+        if (drive?.Type is AbstractDrive.DriveType.Root
+            && Data.DevicesObject?.Current?.MountPoints is { Count: > 0 } mounts)
+        {
+            Models.FileSystemInfo? best = null;
+            foreach (var mount in mounts)
+            {
+                var point = mount.MountPoint;
+                if (string.IsNullOrEmpty(point))
+                    continue;
+
+                if (path == point || path.StartsWith(point.TrimEnd('/') + '/', StringComparison.Ordinal))
+                {
+                    // longest prefix wins; ties go to the later (more recent) mount
+                    if (best is null || point.Length >= best.Value.MountPoint.Length)
+                        best = mount;
+                }
+            }
+
+            if (best is not null)
+                return DriveRestrictions.From(best.Value.Options, best.Value.FileSystemType);
+        }
+
+        return drive?.Restrictions ?? DriveRestrictions.None;
+    }
+
+    /// <summary>Archive-aware variant: resolves a composite archive path to the archive file first.</summary>
+    public static DriveRestrictions GetPathRestrictions(string path, string? deviceId)
+    {
+        if (ArchivePath.IsArchivePath(path, deviceId))
+            path = ArchivePath.GetArchivePath(path, deviceId);
+
+        return GetPathRestrictions(path);
+    }
+
     public static bool IsModificationAllowedAt(string path, string deviceId)
     {
-        if (GetCurrentDrive(path)?.Restrictions.ReadOnly is true)
+        if (GetPathRestrictions(path).ReadOnly)
             return false;
 
         return ArchiveHelper.IsModificationAllowedAt(path, deviceId);

--- a/ADB Explorer/Models/DirectoryLister.cs
+++ b/ADB Explorer/Models/DirectoryLister.cs
@@ -64,6 +64,15 @@ public partial class DirectoryLister(Dispatcher dispatcher, LogicalDeviceViewMod
         StartDirectoryList(path);
     }
 
+    /// <summary>Recursively lists items under path whose name contains query.</summary>
+    public void NavigateToSearch(string path, string query)
+    {
+        ArchivePath.InvalidateCache();
+
+        locationSource = null;
+        StartDirectoryList(path, query);
+    }
+
     public void RefreshLocationAccess()
     {
         if (string.IsNullOrEmpty(currentPath))
@@ -85,7 +94,7 @@ public partial class DirectoryLister(Dispatcher dispatcher, LogicalDeviceViewMod
         IsLinkListingFinished = true;
     }
 
-    private void StartDirectoryList(string path)
+    private void StartDirectoryList(string path, string? searchQuery = null)
     {
         FileClass? source;
         Dispatcher.BeginInvoke(() =>
@@ -103,8 +112,7 @@ public partial class DirectoryLister(Dispatcher dispatcher, LogicalDeviceViewMod
             source = locationSource;
             locationSource = null;
 
-            var drivePath = ArchivePath.IsArchivePath(path, Device.ID) ? ArchivePath.GetArchivePath(path, Device.ID) : path;
-            var restrictions = DriveHelper.GetCurrentDrive(drivePath)?.Restrictions ?? DriveRestrictions.None;
+            var restrictions = DriveHelper.GetPathRestrictions(path, Device.ID);
             var preliminary = FileClass.BuildCurrentLocation(path, null, source, Device.ShellIdentity, restrictions, Device.ID);
             CurrentLocation = preliminary;
         }).Wait();
@@ -114,8 +122,12 @@ public partial class DirectoryLister(Dispatcher dispatcher, LogicalDeviceViewMod
         currentFileQueue = new ConcurrentQueue<FileStat>();
 
         ReadTask = Task.Run(() =>
-            ADBService.ListDirectory(Device.ID, path, ref currentFileQueue, Dispatcher, CurrentCancellationToken.Token),
-            CurrentCancellationToken.Token);
+        {
+            if (searchQuery is null)
+                ADBService.ListDirectory(Device.ID, path, ref currentFileQueue, Dispatcher, CurrentCancellationToken.Token);
+            else
+                ADBService.SearchDirectory(Device.ID, path, searchQuery, ref currentFileQueue, Dispatcher, CurrentCancellationToken.Token);
+        }, CurrentCancellationToken.Token);
         ReadTask.ContinueWith((t) => Dispatcher.BeginInvoke(() => StopDirectoryList()), CurrentCancellationToken.Token);
 
         Task.Delay(DIR_LIST_VISIBLE_PROGRESS_DELAY).ContinueWith((t) => Dispatcher.BeginInvoke(() => IsProgressVisible = InProgress), CurrentCancellationToken.Token);
@@ -233,8 +245,7 @@ public partial class DirectoryLister(Dispatcher dispatcher, LogicalDeviceViewMod
             return;
 
         var identity = Device.GetOrLoadShellIdentity();
-        var drivePath = ArchivePath.IsArchivePath(path, Device.ID) ? ArchivePath.GetArchivePath(path, Device.ID) : path;
-        var restrictions = DriveHelper.GetCurrentDrive(drivePath)?.Restrictions ?? DriveRestrictions.None;
+        var restrictions = DriveHelper.GetPathRestrictions(path, Device.ID);
 
         LocationInfo? info = null;
         if (!ArchivePath.IsArchivePath(path, Device.ID))
@@ -281,32 +292,62 @@ public partial class DirectoryLister(Dispatcher dispatcher, LogicalDeviceViewMod
             if (items.Count < 1)
                 return;
 
-            List<(string, FileType)> result;
-            try
+            // batch so the readlink script stays under the command-line limit (search can return many links)
+            foreach (var batch in BatchLinkItems(items))
             {
-                result = [.. ADBService.GetLinkType(Device.ID, items.Select(f => f.FullPath), cancellationToken)];
-            }
-            catch (OperationCanceledException)
-            {
-                return;
-            }
-
-            for (var i = 0; i < items.Count; i++)
-            {
-                var file = items[i];
-                var target = result[i];
-
-                Dispatcher.Invoke(() =>
+                List<(string, FileType)> result;
+                try
                 {
-                    file.LinkTarget = target.Item1;
-                    file.Type = target.Item2;
-                    file.UpdateType();
-                });
+                    result = [.. ADBService.GetLinkType(Device.ID, batch.Select(f => f.FullPath), cancellationToken)];
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+
+                for (var i = 0; i < batch.Count && i < result.Count; i++)
+                {
+                    var file = batch[i];
+                    var target = result[i];
+
+                    Dispatcher.Invoke(() =>
+                    {
+                        file.LinkTarget = target.Item1;
+                        file.Type = target.Item2;
+                        file.UpdateType();
+                    });
+                }
             }
         }
         finally
         {
             Dispatcher.BeginInvoke(() => IsLinkListingFinished = true);
         }
+    }
+
+    private static IEnumerable<List<FileClass>> BatchLinkItems(List<FileClass> items)
+    {
+        // the script inlines each path twice, plus per-entry overhead
+        const int maxBatchChars = 8000;
+        const int maxBatchCount = 40;
+
+        List<FileClass> batch = [];
+        var chars = 0;
+
+        foreach (var item in items)
+        {
+            batch.Add(item);
+            chars += item.FullPath.Length * 2 + 64;
+
+            if (batch.Count >= maxBatchCount || chars >= maxBatchChars)
+            {
+                yield return batch;
+                batch = [];
+                chars = 0;
+            }
+        }
+
+        if (batch.Count > 0)
+            yield return batch;
     }
 }

--- a/ADB Explorer/Models/Drive/DriveRestrictions.cs
+++ b/ADB Explorer/Models/Drive/DriveRestrictions.cs
@@ -3,7 +3,8 @@ namespace ADB_Explorer.Models;
 public readonly record struct DriveRestrictions(
     bool NoExec,
     bool ReadOnly,
-    bool NoAccessTime)
+    bool NoAccessTime,
+    bool FuseFs = false)
 {
     public static readonly DriveRestrictions None = default;
 
@@ -13,12 +14,12 @@ public readonly record struct DriveRestrictions(
 
     public string IconGlyph => ReadOnly ? "\uE72E" : "\uE7BA";
 
-    public bool NoSymbolicLinks => NoExec;
-    public bool RestrictedNaming => NoExec;
-    public bool CaseInsensitiveNames => NoExec;
+    public bool NoSymbolicLinks => FuseFs;
+    public bool RestrictedNaming => FuseFs;
+    public bool CaseInsensitiveNames => FuseFs;
     public bool NoApkInstall => NoExec;
 
-    public static DriveRestrictions From(string[]? mountOptions)
+    public static DriveRestrictions From(string[]? mountOptions, string? fileSystemType = null)
     {
         if (mountOptions is null || mountOptions.Length == 0)
             return None;
@@ -28,10 +29,25 @@ public readonly record struct DriveRestrictions(
             .Where(o => o.Length > 0)
             .ToHashSet();
 
+        var noExec = HasOption(options, "noexec");
+
         return new(
-            NoExec: HasOption(options, "noexec"),
+            NoExec: noExec,
             ReadOnly: HasOption(options, "ro"),
-            NoAccessTime: HasOption(options, "noatime"));
+            NoAccessTime: HasOption(options, "noatime"),
+            // naming/symlink limits come from FUSE/FAT, not noexec; old callers without an fs type keep the noexec guess
+            FuseFs: fileSystemType is null ? noExec : IsFuseLikeFs(fileSystemType));
+    }
+
+    private static bool IsFuseLikeFs(string fileSystemType)
+    {
+        var type = fileSystemType.ToLowerInvariant();
+
+        return type.Contains("fuse")
+            || type.Contains("sdcardfs")
+            || type.Contains("esdfs")
+            || type.Contains("fat")     // vfat / exfat / fat32
+            || type.Contains("msdos");
     }
 
     private static bool HasOption(HashSet<string> options, string name) =>

--- a/ADB Explorer/Models/File/FileClass.cs
+++ b/ADB Explorer/Models/File/FileClass.cs
@@ -12,7 +12,8 @@ public partial class FileClass : FilePath, IFileStat, IBrowserItem
 {
     #region Notify Properties
 
-    public string ParsedFullPath => Data.CurrentDrive?.LinkTargetPath is null
+    // String.Replace throws on an empty oldValue, so skip the remap when the drive path is blank.
+    public string ParsedFullPath => Data.CurrentDrive?.LinkTargetPath is null || string.IsNullOrEmpty(Data.CurrentDrive.Path)
         ? FullPath
         : FullPath.Replace(Data.CurrentDrive.Path, Data.CurrentDrive.LinkTargetPath);
 

--- a/ADB Explorer/Models/Static/AdbRegEx.cs
+++ b/ADB Explorer/Models/Static/AdbRegEx.cs
@@ -32,7 +32,8 @@
         [GeneratedRegex(@"(?:INSTALL_FAILED_INVALID_APK.*?)(?<package>com\.[\w.]+)(?:])")]
         public static partial Regex RE_PACKAGE_NAME();
 
-        [GeneratedRegex(@"package:(?<Path>\S+\.apk)=(?<Name>\S+) versionCode:(?<Version>\d+) uid:(?<Uid>\d+)")]
+        // versionCode / uid only appear with --show-versioncode / -U, so keep both groups optional
+        [GeneratedRegex(@"package:(?<Path>\S+\.(?:apk|apex))=(?<Name>\S+)(?: versionCode:(?<Version>\d+))?(?: uid:(?<Uid>\d+))?")]
         public static partial Regex RE_PACKAGE_LISTING();
 
         [GeneratedRegex(@"(?:(?<!\d)(?<Date>\d{8})[^\d](?:(?<=[-_])(?<Time>\d{6}))?[^\d])|(?:(?<!\d)(?<DnT>\d{4}(?:[-_]\d{2}){5})[^\d])")]

--- a/ADB Explorer/Services/ADB/ADBService.cs
+++ b/ADB Explorer/Services/ADB/ADBService.cs
@@ -429,10 +429,11 @@ public partial class ADBService
         }
     }
 
+    // Double quotes (not single) around each policy so the whole script can be single-quoted for su -c below.
     const string magiskRootArgs = """
-                magiskpolicy --live 'allow adbd adbd process setcurrent'
-                magiskpolicy --live 'allow adbd su process dyntransition'
-                magiskpolicy --live 'permissive { su }'
+                magiskpolicy --live "allow adbd adbd process setcurrent"
+                magiskpolicy --live "allow adbd su process dyntransition"
+                magiskpolicy --live "permissive { su }"
                 resetprop ro.secure 0
                 resetprop ro.adb.secure 0
                 resetprop ro.force.debuggable 1
@@ -441,26 +442,84 @@ public partial class ADBService
                 resetprop ctl.restart adbd
                 """;
 
-    static string[] RootArgs => ["shell", "su", "-c", EscapeAdbShellString(string.Join(" && ", magiskRootArgs.Split("\r\n", StringSplitOptions.RemoveEmptyEntries)))];
+    static string RootScript => string.Join(" && ", magiskRootArgs.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
 
-    static string[] UnrootArgs => ["shell", "su", "-c", EscapeAdbShellString("resetprop ro.debuggable 0 && resetprop service.adb.root 0 && setprop ctl.restart adbd")];
+    // The device must receive: su -c '<whole script>'  - single-quoted so the entire && chain runs under su
+    // (root), not just the first command, and so the inner double quotes reach magiskpolicy intact.
+    // Commands are launched via CreateProcess with a joined argument string, so the inner double quotes are
+    // backslash-escaped to survive Windows CommandLineToArgvW as one token. EscapeAdbShellString can't be
+    // used here: it double-quotes the payload, which splits the chain and mangles the policy quoting.
+    static string[] RootArgs => ["shell", "su", "-c", $"\"'{RootScript.Replace("\"", "\\\"")}'\""];
+
+    static string[] UnrootArgs => ["shell", "su", "-c", "\"'resetprop ro.debuggable 0 && resetprop service.adb.root 0 && setprop ctl.restart adbd'\""];
 
     public static bool Root(string deviceId)
     {
-        ExecuteDeviceAdbCommand(deviceId, "", out string stdout, out string stderr, CancellationToken.None, RootArgs);
-        if (stdout != "" || stderr != "")
-            ExecuteDeviceAdbCommand(deviceId, "", out stdout, out _, CancellationToken.None, "root");
+        // The script restarts adbd, so its own output is meaningless. Check the shell identity instead.
+        ExecuteDeviceAdbCommand(deviceId, "", out _, out _, CancellationToken.None, RootArgs);
 
-        return !stdout.Contains("cannot run as root");
+        if (WaitForRootShell(deviceId, wantRoot: true))
+            return true;
+
+        // fall back to stock adb root
+        ExecuteDeviceAdbCommand(deviceId, "", out string stdout, out _, CancellationToken.None, "root");
+        if (stdout.Contains("cannot run as root"))
+            return false;
+
+        return WaitForRootShell(deviceId, wantRoot: true);
     }
+
+    /// <summary>Waits for the shell identity to reach the wanted root state after an adbd restart.</summary>
+    private static bool WaitForRootShell(string deviceId, bool wantRoot, int timeoutMs = 5000)
+    {
+        const int stepMs = 250;
+        for (int waited = 0; waited < timeoutMs; waited += stepMs)
+        {
+            ExecuteDeviceAdbCommand(deviceId, "wait-for-device", out _, out _, CancellationToken.None);
+
+            if (GetShellIdentity(deviceId) is ShellIdentity identity && identity.IsRoot == wantRoot)
+                return true;
+
+            Thread.Sleep(stepMs);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Re-runs a binder command (pm/cmd/content) as the shell user when root adbd rejects it with
+    /// "Failed transaction". Needs -Z for the SELinux context, and -Z can't return stdout over the
+    /// root pipe, so the output goes through a temp file. Second attempt covers su without -Z.
+    /// Yields each attempt's stdout; the caller must check it, since su exits 0 even on inner failure.
+    /// </summary>
+    public static IEnumerable<string> ShellUserFallbackAttempts(string deviceId, string shellCmd)
+    {
+        var tmp = $"/data/local/tmp/.adbexplorer_{Guid.NewGuid():N}";
+
+        if (ExecuteDeviceAdbShellCommand(deviceId, "su", out string stdout, out _, CancellationToken.None,
+            ["2000", "-Z", "u:r:shell:s0", "-c", $"'{shellCmd} > {tmp} 2>/dev/null'", ";", "cat", tmp, "2>/dev/null", ";", "rm", "-f", tmp]) == 0)
+            yield return stdout;
+
+        if (ExecuteDeviceAdbShellCommand(deviceId, "su", out stdout, out _, CancellationToken.None,
+            ["2000", "-c", $"'{shellCmd}'"]) == 0)
+            yield return stdout;
+    }
+
+    /// <summary>True when a binder command was rejected (empty or the "Failed transaction" error).</summary>
+    public static bool IsBinderShellFailure(string stdout)
+        => string.IsNullOrWhiteSpace(stdout) || stdout.Contains("Failure calling service") || stdout.Contains("Failed transaction");
 
     public static bool Unroot(string deviceId)
     {
-        ExecuteDeviceAdbCommand(deviceId, "", out string stdout, out string stderr, CancellationToken.None, UnrootArgs);
-        if (stdout != "" || stderr != "")
-            ExecuteDeviceAdbCommand(deviceId, "", out stdout, out _, CancellationToken.None, "unroot");
+        ExecuteDeviceAdbCommand(deviceId, "", out _, out _, CancellationToken.None, UnrootArgs);
 
-        var result = stdout.Contains("restarting adbd as non root");
+        var result = WaitForRootShell(deviceId, wantRoot: false);
+        if (!result)
+        {
+            ExecuteDeviceAdbCommand(deviceId, "", out _, out _, CancellationToken.None, "unroot");
+            result = WaitForRootShell(deviceId, wantRoot: false);
+        }
+
         DevicesObject.UpdateDeviceRoot(deviceId, result);
 
         return result;
@@ -1030,24 +1089,294 @@ public partial class ADBService
         {
             var current = queue.Dequeue();
 
-            IEnumerable<FileStat> entries;
-            try
-            {
-                entries = ListDirectoryEntries(deviceId, current, cancellationToken);
-            }
-            catch (ProcessFailedException)
-            {
-                continue;
-            }
+            // wrap MoveNext, not the whole loop: an unreadable dir should skip itself, not stop the walk
+            using var entries = ListDirectoryEntries(deviceId, current, cancellationToken).GetEnumerator();
 
-            foreach (var entry in entries)
+            while (true)
             {
+                FileStat entry;
+                try
+                {
+                    if (!entries.MoveNext())
+                        break;
+
+                    entry = entries.Current;
+                }
+                catch (Exception e) when (e is not OperationCanceledException)
+                {
+                    // unreadable dir (ProcessFailedException) or one malformed ls line: end this dir, keep the walk
+                    break;
+                }
+
                 yield return entry;
 
                 if (entry.Type is FileType.Folder)
                     queue.Enqueue(entry.FullPath);
             }
         }
+    }
+
+    public static void SearchDirectory(string deviceId, string path, string query, ref ConcurrentQueue<FileStat> output, Dispatcher dispatcher, CancellationToken cancellationToken)
+    {
+        IEnumerable<FileStat> entries;
+        var usingFind = false;
+
+        if (ShellCommands.FindExists(deviceId) && ShellCommands.FindPrintf(deviceId))
+        {
+            entries = SearchEntriesWithFindPrintf(deviceId, path, query, cancellationToken);
+            usingFind = true;
+        }
+        else if (ShellCommands.FindExists(deviceId) && ShellCommands.StatExists(deviceId))
+        {
+            entries = SearchEntriesWithFindStat(deviceId, path, query, cancellationToken);
+            usingFind = true;
+        }
+        else
+        {
+            entries = SearchEntriesWithListing(deviceId, path, query, cancellationToken);
+        }
+
+        var produced = false;
+        var findFailed = false;
+        try
+        {
+            foreach (var item in entries)
+            {
+                output.Enqueue(item);
+                produced = true;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+        catch (ProcessFailedException)
+        {
+            // find exits non-zero on unreadable dirs; only fall back if it produced nothing at all
+            findFailed = true;
+        }
+        catch (Exception e)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return;
+
+            var message = e.Message;
+            if (!string.IsNullOrEmpty(message))
+                message += "\n\n";
+
+            dispatcher.Invoke(() => DialogService.ShowMessage(message + Strings.Resources.S_LS_ERROR,
+                                                              Strings.Resources.S_LS_ERROR_TITLE,
+                                                              DialogService.DialogIcon.Critical,
+                                                              true,
+                                                              copyToClipboard: true,
+                                                              error: DialogError.ListDirectoryFailed));
+            return;
+        }
+
+        if (usingFind && findFailed && !produced && !cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                foreach (var item in SearchEntriesWithListing(deviceId, path, query, cancellationToken))
+                    output.Enqueue(item);
+            }
+            catch (OperationCanceledException)
+            { }
+            catch (ProcessFailedException)
+            { }
+        }
+    }
+
+    /// <summary>adb ls fallback, filtered locally, for when find isn't usable.</summary>
+    private static IEnumerable<FileStat> SearchEntriesWithListing(string deviceId, string path, string query, CancellationToken cancellationToken) =>
+        ListDirectoryRecursive(deviceId, path, cancellationToken)
+            .Where(file => file.FullName.Contains(query, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>Trailing slash so find descends into a symlinked root like /sdcard.</summary>
+    private static string SearchRoot(string path) => path.EndsWith('/') ? path : path + '/';
+
+    /// <summary>Escapes glob chars so the query matches literally, like the view filter.</summary>
+    private static string EscapeSearchGlob(string query) =>
+        query.Replace("\\", "\\\\").Replace("[", "\\[").Replace("]", "\\]").Replace("*", "\\*").Replace("?", "\\?");
+
+    private static IEnumerable<FileStat> SearchEntriesWithFindPrintf(string deviceId, string path, string query, CancellationToken cancellationToken)
+    {
+        var find = ShellCommands.TranslateCommand("find");
+
+        // %M not %y: toybox find has -printf but error-exits on %y. \n stays literal so find emits the newline.
+        var format = EscapeAdbShellString($"%M{ADB_FIELD_SEP}%s{ADB_FIELD_SEP}%T@{ADB_FIELD_SEP}%p\\n");
+
+        foreach (var line in ExecuteDeviceAdbCommandAsync(deviceId,
+                                                          "shell",
+                                                          cancellationToken,
+                                                          find,
+                                                          EscapeAdbShellString(SearchRoot(path)),
+                                                          "-mindepth", "1",
+                                                          "-iname", EscapeAdbShellString($"*{EscapeSearchGlob(query)}*"),
+                                                          "-printf", format,
+                                                          @"2>/dev/null"))
+        {
+            if (CreateFileFromFindPrintf(line) is FileStat item)
+                yield return item;
+        }
+    }
+
+    private static FileStat? CreateFileFromFindPrintf(string stdoutLine)
+    {
+        var parts = stdoutLine.Split(ADB_FIELD_SEP, 4);
+        if (parts.Length < 4 || string.IsNullOrEmpty(parts[3]))
+            return null;
+
+        // "//" can appear after the search root; a relative path is a fragment of a newline filename
+        var fullPath = parts[3].Replace("//", "/");
+        if (!fullPath.StartsWith('/'))
+            return null;
+
+        var name = fullPath[(fullPath.LastIndexOf('/') + 1)..];
+
+        // first char of the mode string, e.g. "drwxr-xr-x"
+        var type = parts[0].FirstOrDefault() switch
+        {
+            'd' => FileType.Folder,
+            '-' => FileType.File,
+            's' => FileType.Socket,
+            'b' => FileType.BlockDevice,
+            'c' => FileType.CharDevice,
+            'p' => FileType.FIFO,
+            _ => FileType.Unknown,
+        };
+        var isLink = parts[0].FirstOrDefault() == 'l';
+
+        long? size = long.TryParse(parts[1], out var parsedSize) ? parsedSize : null;
+        if (type is not FileType.File)
+            size = null;
+
+        // %T@ is epoch seconds, maybe with a fractional part
+        var seconds = parts[2].Split('.')[0];
+        DateTime? modified = long.TryParse(seconds, out var secs) && secs > 0
+            ? DateTimeOffset.FromUnixTimeSeconds(secs).DateTime.ToLocalTime()
+            : null;
+
+        return new(
+            FullName: name,
+            FullPath: fullPath,
+            Type: type,
+            IsLink: isLink,
+            Size: size,
+            ModifiedTime: modified,
+            Permissions: null);
+    }
+
+    private const int SEARCH_STAT_CHUNK_SIZE = 50;
+    // keeps each stat call under the 32767-char Windows command-line limit
+    private const int SEARCH_STAT_CHUNK_CHARS = 16000;
+
+    private static IEnumerable<FileStat> SearchEntriesWithFindStat(string deviceId, string path, string query, CancellationToken cancellationToken)
+    {
+        var find = ShellCommands.TranslateCommand("find");
+
+        using var foundPaths = ExecuteDeviceAdbCommandAsync(deviceId,
+                                                            "shell",
+                                                            cancellationToken,
+                                                            find,
+                                                            EscapeAdbShellString(SearchRoot(path)),
+                                                            "-mindepth", "1",
+                                                            "-iname", EscapeAdbShellString($"*{EscapeSearchGlob(query)}*"),
+                                                            @"2>/dev/null").GetEnumerator();
+
+        List<string> chunk = new(SEARCH_STAT_CHUNK_SIZE);
+        var chunkChars = 0;
+
+        while (true)
+        {
+            bool hasNext;
+            try
+            {
+                hasNext = foundPaths.MoveNext();
+            }
+            catch (ProcessFailedException)
+            {
+                // find exits non-zero on any unreadable dir
+                hasNext = false;
+            }
+
+            if (hasNext && !string.IsNullOrEmpty(foundPaths.Current))
+            {
+                chunk.Add(foundPaths.Current);
+                // escaping at most doubles the length; +3 for quotes and space
+                chunkChars += foundPaths.Current.Length * 2 + 3;
+            }
+
+            if (chunk.Count >= SEARCH_STAT_CHUNK_SIZE || chunkChars >= SEARCH_STAT_CHUNK_CHARS || (!hasNext && chunk.Count > 0))
+            {
+                foreach (var item in StatSearchResults(deviceId, chunk, cancellationToken))
+                    yield return item;
+
+                chunk.Clear();
+                chunkChars = 0;
+            }
+
+            if (!hasNext)
+                yield break;
+        }
+    }
+
+    private static IEnumerable<FileStat> StatSearchResults(string deviceId, IEnumerable<string> paths, CancellationToken cancellationToken)
+    {
+        // %f hex mode, %s size, %Y mtime (epoch), %n name. Exit code ignored: files may vanish before stat runs.
+        ExecuteDeviceAdbShellCommand(deviceId,
+                                     "stat",
+                                     out string stdout,
+                                     out _,
+                                     cancellationToken,
+                                     ["-c", $"%f{ADB_FIELD_SEP}%s{ADB_FIELD_SEP}%Y{ADB_FIELD_SEP}%n", .. paths.Select(item => EscapeAdbShellString(item)), @"2>/dev/null"]);
+
+        foreach (var line in stdout.Split(LINE_SEPARATORS, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (CreateFileFromStat(line) is FileStat item)
+                yield return item;
+        }
+    }
+
+    private static FileStat? CreateFileFromStat(string stdoutLine)
+    {
+        var parts = stdoutLine.Split(ADB_FIELD_SEP, 4);
+        if (parts.Length < 4 || string.IsNullOrEmpty(parts[3]))
+            return null;
+
+        if (!UInt32.TryParse(parts[0], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var modeValue))
+            return null;
+
+        // "//" can appear after the search root; a relative path is a fragment of a newline filename
+        var fullPath = parts[3].Replace("//", "/");
+        if (!fullPath.StartsWith('/'))
+            return null;
+
+        var name = fullPath[(fullPath.LastIndexOf('/') + 1)..];
+
+        var mode = (UnixFileMode)modeValue;
+        var type = ParseFileMode(mode);
+
+        long? size = long.TryParse(parts[1], out var parsedSize) ? parsedSize : null;
+        if (mode is UnixFileMode.None || type is FileType.Folder)
+            size = null;
+
+        DateTime? modified = long.TryParse(parts[2], out var secs) && secs > 0
+            ? DateTimeOffset.FromUnixTimeSeconds(secs).DateTime.ToLocalTime()
+            : null;
+
+        UnixFileMode? permissions = mode is UnixFileMode.None
+            ? null
+            : mode & (UnixFileMode)511;
+
+        return new(
+            FullName: name,
+            FullPath: fullPath,
+            Type: type,
+            IsLink: mode.HasFlag(UnixFileMode.S_IFLNK),
+            Size: size,
+            ModifiedTime: modified,
+            Permissions: (System.IO.UnixFileMode?)permissions);
     }
 
     public static string TranslateDevicePath(string deviceId, string path)

--- a/ADB Explorer/Services/ADB/ShellCommands.cs
+++ b/ADB Explorer/Services/ADB/ShellCommands.cs
@@ -80,7 +80,9 @@ public static class ShellCommands
 
     public static string[] Commands => Enum.GetNames<ShellCmd>();
 
-    public static Dictionary<string, DeviceShellCommands> DeviceCommands { get; set; } = [];
+    // Concurrent: written on thread-pool threads by FindCommands and read concurrently elsewhere (incl. the
+    // auto-open capability-probe wait), so a plain Dictionary would risk torn reads / corruption on connect.
+    public static ConcurrentDictionary<string, DeviceShellCommands> DeviceCommands { get; set; } = new();
 
     public static bool FindExists(string deviceId)
         => !DeviceCommands.TryGetValue(deviceId, out var commands) || commands.FindExists;

--- a/ADB Explorer/Services/AppInfra/AppSettings.cs
+++ b/ADB Explorer/Services/AppInfra/AppSettings.cs
@@ -150,8 +150,10 @@ public partial class AppSettings : ObservableObject, IJsonOnDeserialized, IJsonO
         }
     }
 
+    // Require the folder to still exist: a stale DefaultFolder (deleted/unmounted after being set) would
+    // otherwise make double-click-to-pull fire at a dead path and fail.
     [JsonIgnore]
-    public bool IsPullOnDoubleClickEnabled => !string.IsNullOrEmpty(DefaultFolder);
+    public bool IsPullOnDoubleClickEnabled => !string.IsNullOrEmpty(DefaultFolder) && Directory.Exists(DefaultFolder);
 
     [ObservableProperty]
     public partial string ManualAdbPath { get; set; } = "";

--- a/ADB Explorer/Services/AppInfra/DebugLog.cs
+++ b/ADB Explorer/Services/AppInfra/DebugLog.cs
@@ -4,13 +4,28 @@ public static class DebugLog
 {
     private static readonly Mutex mutex = new();
 
+    // usable only on a dev machine, where the log dir exists
+    private static readonly bool logPathUsable =
+        !string.IsNullOrEmpty(Properties.AppGlobal.DragDropLogPath)
+        && Directory.Exists(Path.GetDirectoryName(Properties.AppGlobal.DragDropLogPath));
+
     public static void PrintLine(string message)
     {
-        mutex.WaitOne();
-        
-        if (!string.IsNullOrEmpty(Properties.AppGlobal.DragDropLogPath))
-            File.AppendAllText(Properties.AppGlobal.DragDropLogPath, $"{DateTime.Now:HH:mm:ss:fff} | {message}\n");
+        if (!logPathUsable)
+            return;
 
-        mutex.ReleaseMutex();
+        mutex.WaitOne();
+        try
+        {
+            File.AppendAllText(Properties.AppGlobal.DragDropLogPath, $"{DateTime.Now:HH:mm:ss:fff} | {message}\n");
+        }
+        catch (SystemException)
+        {
+            // never crash over a log write
+        }
+        finally
+        {
+            mutex.ReleaseMutex();
+        }
     }
 }

--- a/ADB Explorer/Services/AppInfra/DevicePollingService.cs
+++ b/ADB Explorer/Services/AppInfra/DevicePollingService.cs
@@ -11,6 +11,29 @@ public class DevicePollingService : BackgroundService
 {
     private static bool isDevicesPage = true;
 
+    // Set while a device is being opened/set up (DeviceHelper.InitDevice); pauses polling so it doesn't
+    // race the setup and pile concurrent UI updates onto the UI thread.
+    private static volatile bool _deviceSetupInProgress;
+    private static long _deviceSetupStartedTick;
+
+    // Safety cap: InitDevice awaits blocking adb calls with no timeout, so if a device wedges its `finally`
+    // may never clear the flag. Never pause polling for longer than this, or the device list would freeze.
+    private const long DeviceSetupPauseCapMs = 10_000;
+
+    public static bool IsDeviceSetupInProgress
+    {
+        get => _deviceSetupInProgress;
+        set
+        {
+            _deviceSetupInProgress = value;
+            if (value)
+                _deviceSetupStartedTick = Environment.TickCount64;
+        }
+    }
+
+    private static bool ShouldPauseForSetup =>
+        _deviceSetupInProgress && Environment.TickCount64 - _deviceSetupStartedTick < DeviceSetupPauseCapMs;
+
     private static int pollingInterval => isDevicesPage ? 500 : 2000;
 
     public DevicePollingService()
@@ -28,6 +51,7 @@ public class DevicePollingService : BackgroundService
             try
             {
                 if (!Data.RuntimeSettings.IsPollingStopped
+                    && !ShouldPauseForSetup
                     && AdbHelper.CurrentAdbState.Status is AdbHelper.AdbStatus.Valid
                     && Data.DevicesObject is not null)
                 {
@@ -55,8 +79,13 @@ public class DevicePollingService : BackgroundService
             DeviceHelper.UpdateDevicesBatInfo(cancellationToken);
         }
 
-        if (Data.FileActions.IsDriveViewVisible && Data.Settings.PollDrives)
+        // Drive tile counts (storage, recycle, installers, packages) change rarely, but refreshing them runs
+        // ~8 adb commands (df/find/pm + the su count fallback) plus a UI update. At the 2s poll rate that is a
+        // constant churn/stutter while the drive view is open, so throttle it well below the base poll rate.
+        if (Data.FileActions.IsDriveViewVisible && Data.Settings.PollDrives
+            && Environment.TickCount64 - _lastDrivePollTick >= DrivePollIntervalMs)
         {
+            _lastDrivePollTick = Environment.TickCount64;
             FileActionLogic.RefreshDrives(true, cancellationToken);
         }
 
@@ -81,6 +110,13 @@ public class DevicePollingService : BackgroundService
         if (!isDevicesPage)
             return;
 
+        // The Devices page polls every 500ms, but the work below (IP lookup, mDNS scan, per-device root
+        // re-check, WSA/emulator status) is expensive and marshals onto the UI thread synchronously - running
+        // it twice a second is what causes the stutter. Throttle it; the device LIST above still updates every poll.
+        if (Environment.TickCount64 - _lastHeavyDevicePollTick < HeavyDevicePollIntervalMs)
+            return;
+        _lastHeavyDevicePollTick = Environment.TickCount64;
+
         Data.DevicesObject.UpdateLogicalIp();
 
         if (Data.MdnsService?.State is MDNS.MdnsState.Running)
@@ -97,6 +133,12 @@ public class DevicePollingService : BackgroundService
         }
     }
 
+    private static long _lastHeavyDevicePollTick;
+    private const long HeavyDevicePollIntervalMs = 2000;
+
+    private static long _lastDrivePollTick;
+    private const long DrivePollIntervalMs = 6000;
+
     private static void ListDevices(IEnumerable<DeviceSnapshot> snapshots)
     {
         if (snapshots is null)
@@ -109,13 +151,9 @@ public class DevicePollingService : BackgroundService
 
         DeviceHelper.DeviceListSetup(deviceVMs);
 
-        if (!Data.Settings.AutoRoot)
-            return;
-
-        foreach (var item in Data.DevicesObject.LogicalDeviceViewModels.Where(device => device.Root is RootStatus.Unchecked).ToList())
-        {
-            item.EnableRoot(true);
-        }
+        // AutoRoot is NOT triggered here: enabling root restarts adbd, and doing that the instant a device
+        // connects collides with the concurrent device setup. It now runs at the end of DeviceHelper.InitDevice,
+        // once setup has completed.
     }
 }
 

--- a/ADB Explorer/Services/AppInfra/FileAction/FileActionLogic.cs
+++ b/ADB Explorer/Services/AppInfra/FileAction/FileActionLogic.cs
@@ -294,7 +294,7 @@ internal static class FileActionLogic
         if (Data.FileActions.IsArchive)
             return false;
 
-        if (Data.CurrentDrive?.Restrictions.ReadOnly is true)
+        if (CurrentPathRestrictions().ReadOnly)
             return false;
 
         string[] files = Data.CopyPaste.Files;
@@ -358,7 +358,7 @@ internal static class FileActionLogic
         if (Data.FileActions.IsArchive)
             return false;
 
-        if (Data.CurrentDrive?.Restrictions.ReadOnly is true)
+        if (CurrentPathRestrictions().ReadOnly)
             return false;
 
         string[] files = Data.CopyPaste.Files;
@@ -485,14 +485,26 @@ internal static class FileActionLogic
         return fromArchive ? result : result | DragDropEffects.Move;
     }
 
+    /// <summary>Restrictions of the current location (archive-aware), falling back to the drive.</summary>
+    public static DriveRestrictions CurrentPathRestrictions()
+        => Data.DirList?.CurrentPath is { } path
+            ? DriveHelper.GetPathRestrictions(path, Data.DevicesObject?.Current?.ID)
+            : Data.CurrentDrive?.Restrictions ?? DriveRestrictions.None;
+
+    /// <summary>Restrictions of the selection's own mount, which in search results can differ from the folder's.</summary>
+    private static DriveRestrictions SelectionRestrictions()
+        => Data.FileActions.IsExplorerSearchResults && Data.SelectedFiles.FirstOrDefault() is { } selected
+            ? DriveHelper.GetPathRestrictions(selected.ParentPath, Data.DevicesObject?.Current?.ID)
+            : CurrentPathRestrictions();
+
     private static void UpdatePastingRestrictions(string targetPath, string[] files)
     {
-        var restrictions = DriveHelper.GetCurrentDrive(targetPath)?.Restrictions ?? DriveRestrictions.None;
+        var restrictions = DriveHelper.GetPathRestrictions(targetPath);
 
         if (Data.FileActions.IsAppDrive)
         {
             Data.FileActions.IsPastingIllegalNaming = Data.CopyPaste.IsSelf
-                && (DriveHelper.GetCurrentDrive(files[0])?.Restrictions.RestrictedNaming is true);
+                && DriveHelper.GetPathRestrictions(files[0]).RestrictedNaming;
             return;
         }
 
@@ -563,7 +575,7 @@ internal static class FileActionLogic
         var name = FileHelper.DisplayName(textBox);
 
         if (!vm.IsRenameUnixLegal
-            || (Data.CurrentDrive?.Restrictions.RestrictedNaming is true && !vm.IsRenameNamingLegal)
+            || (SelectionRestrictions().RestrictedNaming && !vm.IsRenameNamingLegal)
             || !vm.IsRenameUnique)
         {
             return;
@@ -682,10 +694,19 @@ internal static class FileActionLogic
         Data.RuntimeSettings.LocationToNavigate = new(Data.CurrentPath);
     }
 
+    private static long _lastDriveRefreshTick;
+
     public static void RefreshDrives(bool asyncClassify, CancellationToken cancellationToken)
     {
         if (Data.DevicesObject.Current is null)
             return;
+
+        // Debounce overlapping refreshes: at startup the device poll and the navigation both trigger this
+        // within milliseconds, doubling every drive command (df/find/pm) and its UI update. They describe the
+        // same drive state, so collapse near-simultaneous calls into one. The 2s poll is never affected.
+        if (Environment.TickCount64 - _lastDriveRefreshTick < 300)
+            return;
+        _lastDriveRefreshTick = Environment.TickCount64;
 
         if (!asyncClassify && Data.DevicesObject.Current.Drives?.Count > 0 && !Data.FileActions.IsExplorerVisible)
             asyncClassify = true;
@@ -861,13 +882,19 @@ internal static class FileActionLogic
                                                && Data.SelectedFiles.First().IsLink
                                                && Data.SelectedFiles.First().Type is not FileType.BrokenLink;
 
-        var restrictions = Data.CurrentDrive?.Restrictions ?? DriveRestrictions.None;
+        var restrictions = CurrentPathRestrictions();
+        var selectionRestrictions = SelectionRestrictions();
         var deviceId = Data.DevicesObject?.Current?.ID;
         if (deviceId is not null && Data.DirList?.CurrentPath is { } currentPath)
             Data.FileActions.IsArchive = ArchivePath.IsArchivePath(currentPath, deviceId);
 
         var isWritable = restrictions.ReadOnly is not true
             && Data.DirList?.CurrentLocation?.CanWriteLocation == true;
+
+        // in search results, gate on the selected item's mount (its access isn't probed per-item)
+        var isSelectionWritable = Data.FileActions.IsExplorerSearchResults && Data.SelectedFiles.Any()
+            ? !selectionRestrictions.ReadOnly
+            : isWritable;
         var isExplorerFolder = Data.FileActions.IsExplorerVisible
             && !Data.FileActions.IsRecycleBin
             && !Data.FileActions.IsAppDrive
@@ -886,7 +913,7 @@ internal static class FileActionLogic
         }
         else
         {
-            Data.FileActions.DeleteEnabled = isWritable
+            Data.FileActions.DeleteEnabled = isSelectionWritable
                 && !SelectionIsFuseProtectedAndroidRoot
                 && Data.SelectedFiles.Any() && Data.FileActions.IsRegularItem
                 && (!Data.FileActions.IsFollowLinkEnabled || HasRootShell);
@@ -918,7 +945,7 @@ internal static class FileActionLogic
             && Data.SelectedFiles.Any()
             && !FileHelper.FileNameLegal(Data.SelectedFiles, FileHelper.RenameTarget.RestrictedNaming);
         Data.FileActions.IsSelectionIllegalOnWinRoot = Data.SelectedFiles.Any() && !FileHelper.FileNameLegal(Data.SelectedFiles, FileHelper.RenameTarget.WinRoot);
-        Data.FileActions.IsSelectionConflictingNames = restrictions.CaseInsensitiveNames
+        Data.FileActions.IsSelectionConflictingNames = selectionRestrictions.CaseInsensitiveNames
             && Data.SelectedFiles.Select(f => f.FullName).Distinct(StringComparer.InvariantCultureIgnoreCase).Count() != Data.SelectedFiles.Count();
 
         // Pull from archive extracts selected members to /data/local/tmp then pulls (same as PrepareDescriptors).
@@ -937,7 +964,7 @@ internal static class FileActionLogic
             && !Data.FileActions.IsRecycleBin && !Data.FileActions.IsAppDrive && !Data.FileActions.IsArchive
             && (!Data.SelectedFiles.Any() || (Data.SelectedFiles.Count() == 1 && Data.SelectedFiles.First().IsDirectory));
 
-        Data.FileActions.RenameEnabled = isWritable
+        Data.FileActions.RenameEnabled = isSelectionWritable
                                          && !Data.FileActions.IsArchive
                                          && !SelectionIsFuseProtectedAndroidRoot
                                          && !Data.FileActions.IsRecycleBin
@@ -950,7 +977,7 @@ internal static class FileActionLogic
                                 && Data.CopyPaste.Files.Length == Data.SelectedFiles.Count();
         
         // Cut from archive is not supported (extract is copy-only).
-        Data.FileActions.CutEnabled = isWritable
+        Data.FileActions.CutEnabled = isSelectionWritable
                                       && !Data.FileActions.IsArchive
                                       && !SelectionIsFuseProtectedAndroidRoot
                                       && Data.SelectedFiles.AnyAll(f => f.Type is not FileType.BrokenLink)
@@ -989,15 +1016,15 @@ internal static class FileActionLogic
         Data.FileActions.ContextNewEnabled = isWritable
             && !Data.SelectedFiles.Any() && !Data.FileActions.IsRecycleBin && !Data.FileActions.IsAppDrive;
 
-        Data.FileActions.SubmenuUninstallEnabled = Data.CurrentDrive?.Restrictions.NoApkInstall is not true
+        Data.FileActions.SubmenuUninstallEnabled = !selectionRestrictions.NoApkInstall
             && Data.SelectedFiles.AnyAll(file => file.IsInstallApk)
             && Data.DevicesObject?.Current?.Type is not DeviceType.Recovery;
 
-        Data.FileActions.UpdateModifiedEnabled = isWritable
+        Data.FileActions.UpdateModifiedEnabled = isSelectionWritable
             && !Data.FileActions.IsRecycleBin
             && Data.SelectedFiles.AnyAll(file => file.Type is FileType.File && !file.IsApk && !file.IsLink);
 
-        Data.FileActions.IsPasteLinkEnabled = Data.CurrentDrive?.Restrictions.NoSymbolicLinks is not true
+        Data.FileActions.IsPasteLinkEnabled = !restrictions.NoSymbolicLinks
             && HasRootShell
             && Data.CopyPaste.Files.Length == 1
             && Data.CopyPaste.IsSelf
@@ -1006,7 +1033,7 @@ internal static class FileActionLogic
             (Data.SelectedFiles.Count() == 1 && Data.SelectedFiles.First().IsDirectory));
 
         Data.FileActions.InstallPackageEnabled = Data.DevicesObject?.Current?.Type is not DeviceType.Recovery
-            && Data.CurrentDrive?.Restrictions.NoApkInstall is not true;
+            && !selectionRestrictions.NoApkInstall;
 
         if (!Data.CopyPaste.IsDrag)
             Data.RuntimeSettings.FilterActions = true;
@@ -1143,7 +1170,8 @@ internal static class FileActionLogic
             {
                 IsFolderPicker = true,
                 Multiselect = false,
-                DefaultDirectory = Data.Settings.DefaultFolder,
+                // Skip a stale DefaultFolder so the picker doesn't fail to open on a dead start directory.
+                DefaultDirectory = Directory.Exists(Data.Settings.DefaultFolder) ? Data.Settings.DefaultFolder : null,
                 Title = pullItems.Count() > 1
                     ? Strings.Resources.S_ITEM_DESTINATION_PLURAL
                     : string.Format(Strings.Resources.S_ITEM_DESTINATION, pullItems.First()),

--- a/ADB Explorer/Services/AppInfra/FileAction/FileActionsEnable.cs
+++ b/ADB Explorer/Services/AppInfra/FileAction/FileActionsEnable.cs
@@ -322,6 +322,14 @@ public partial class FileActionsEnable : ObservableObject
         set => SetProperty(ref isExplorerEditing, value);
     }
 
+    private bool isExplorerSearchResults = false;
+    /// <summary>Explorer is showing search results, not the current folder.</summary>
+    public bool IsExplorerSearchResults
+    {
+        get => isExplorerSearchResults;
+        set => SetProperty(ref isExplorerSearchResults, value);
+    }
+
     private bool isFollowLinkEnabled = false;
     public bool IsFollowLinkEnabled
     {

--- a/ADB Explorer/Services/FileOpSnackbarService.cs
+++ b/ADB Explorer/Services/FileOpSnackbarService.cs
@@ -101,11 +101,20 @@ public class FileOpSnackbarService(ISnackbarService snackbarService, HashSet<str
 
     private bool _isShowing = false;
 
+    // Keep the snackbar up at least this long so a fast (small-file) operation doesn't just flash.
+    private static readonly TimeSpan MinDisplay = TimeSpan.FromMilliseconds(1500);
+    private long _shownAtTick;
+    private DispatcherTimer? _hideTimer;
+
     private void ShowSnackbar(ObservableList<FileOperation> operations)
     {
         var presenter = snackbarService.GetSnackbarPresenter();
         if (presenter is null)
             return;
+
+        // A new operation started - cancel any pending minimum-display hide.
+        _hideTimer?.Stop();
+        _hideTimer = null;
 
         if (_snackbar is null || _content is null)
         {
@@ -121,7 +130,7 @@ public class FileOpSnackbarService(ISnackbarService snackbarService, HashSet<str
             };
             _snackbar.ProgressValue = _subscribedQueue?.Progress ?? 0.0;
         }
-        
+
         _content.OperationsSource = operations;
 
         if (operations.FirstOrDefault() is { } firstOp)
@@ -130,16 +139,44 @@ public class FileOpSnackbarService(ISnackbarService snackbarService, HashSet<str
         if (!_isShowing)
         {
             _isShowing = true;
+            _shownAtTick = Environment.TickCount64;
             _ = presenter.ImmediatelyDisplay(_snackbar);
         }
     }
 
     private void HideSnackbar()
     {
-        if (_isShowing && snackbarService.GetSnackbarPresenter() is { } presenter)
+        if (!_isShowing)
+            return;
+
+        // Enforce a minimum on-screen time: if it hasn't been shown long enough, defer the hide.
+        var remaining = MinDisplay.TotalMilliseconds - (Environment.TickCount64 - _shownAtTick);
+        if (remaining > 0)
         {
-            _isShowing = false;
-            _ = presenter.HideCurrent();
+            _hideTimer?.Stop();
+            _hideTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(remaining) };
+            _hideTimer.Tick += (_, _) =>
+            {
+                _hideTimer?.Stop();
+                _hideTimer = null;
+                HideNow();
+            };
+            _hideTimer.Start();
+            return;
         }
+
+        HideNow();
+    }
+
+    private void HideNow()
+    {
+        if (!_isShowing)
+            return;
+
+        // Clear the flag even if the presenter is momentarily unavailable, so the snackbar can't get stuck
+        // "showing" forever and block future operations from displaying.
+        _isShowing = false;
+        if (snackbarService.GetSnackbarPresenter() is { } presenter)
+            _ = presenter.HideCurrent();
     }
 }

--- a/ADB Explorer/Services/FileOperation/ShellFileOperation.cs
+++ b/ADB Explorer/Services/FileOperation/ShellFileOperation.cs
@@ -524,19 +524,42 @@ public static class ShellFileOperation
 
     public static ulong? GetPackagesCount(LogicalDeviceViewModel device)
     {
-        var result = ADBService.ExecuteDeviceAdbShellCommand(device.ID, "pm", out string stdout, out _, CancellationToken.None, ["list", "packages", "|", "wc", "-l"]);
-        if (result != 0 || !ulong.TryParse(stdout, out ulong value))
-            return null;
+        // Honor "Show system apps": with it off, count third-party packages only (-3) so the tile matches
+        // the listing (~user apps) instead of everything. Runs on the 2s drive poll - kept simple (no cache):
+        // count directly, and if pm is blocked (root adbd) retry once as the shell user, every poll.
+        var listArg = Data.Settings.ShowSystemPackages ? "list packages" : "list packages -3";
 
-        return value;
+        ADBService.ExecuteDeviceAdbShellCommand(device.ID, "pm", out string stdout, out _, CancellationToken.None,
+            [.. listArg.Split(' '), "2>/dev/null", "|", "grep", "-c", "^package:"]);
+
+        if (ulong.TryParse(stdout.Trim(), out ulong value) && value > 0)
+            return value;
+
+        foreach (var output in ADBService.ShellUserFallbackAttempts(device.ID, $"pm {listArg} 2>/dev/null | grep -c ^package:"))
+        {
+            if (ulong.TryParse(output.Trim(), out ulong suValue) && suValue > 0)
+                return suValue;
+        }
+
+        return null;
     }
 
     public static ObservableList<Package> GetPackages(LogicalDeviceViewModel device, bool includeSystem = true, bool optionalParams = true)
     {
+        var packages = ListPackages(device, includeSystem, optionalParams);
+
+        // some devices reject -U / --show-versioncode; retry without them
+        if (packages.Count == 0 && optionalParams)
+            packages = ListPackages(device, includeSystem, false);
+
+        return packages;
+    }
+
+    private static ObservableList<Package> ListPackages(LogicalDeviceViewModel device, bool includeSystem, bool optionalParams)
+    {
         // More package-specific info can be acquired using dumpsys package [package_name]
 
         ObservableList<Package> packages = [];
-        string stdout = "";
         string[] args = ["list", "packages", "-s", "-f"];
         if (optionalParams)
             args = [.. args, "-U", "--show-versioncode"];
@@ -544,20 +567,41 @@ public static class ShellFileOperation
         if (includeSystem)
         {
             // get system packages
-            var systemExitCode = ADBService.ExecuteDeviceAdbShellCommand(device.ID, "pm", out stdout, out _, CancellationToken.None, args);
-
-            if (systemExitCode == 0)
-                packages.AddRange(stdout.Split(ADBService.LINE_SEPARATORS, StringSplitOptions.RemoveEmptyEntries).Select(pkg => Package.New(pkg, Package.PackageType.System)));
+            if (RunPmListing(device.ID, args, out string stdout))
+                packages.AddRange(stdout.Split(ADBService.LINE_SEPARATORS, StringSplitOptions.RemoveEmptyEntries)
+                                        .Select(pkg => Package.New(pkg, Package.PackageType.System))
+                                        .OfType<Package>());
         }
 
         args[2] = "-3";
         // get user packages
-        var userExitCode = ADBService.ExecuteDeviceAdbShellCommand(device.ID, "pm", out stdout, out _, CancellationToken.None, args);
-
-        if (userExitCode == 0)
-            packages.AddRange(stdout.Split(ADBService.LINE_SEPARATORS, StringSplitOptions.RemoveEmptyEntries).Select(pkg => Package.New(pkg, Package.PackageType.User)));
+        if (RunPmListing(device.ID, args, out string userStdout))
+            packages.AddRange(userStdout.Split(ADBService.LINE_SEPARATORS, StringSplitOptions.RemoveEmptyEntries)
+                                    .Select(pkg => Package.New(pkg, Package.PackageType.User))
+                                    .OfType<Package>());
 
         return packages;
+    }
+
+    /// <summary>Runs a pm listing, retrying as the shell user when root adbd rejects it.</summary>
+    private static bool RunPmListing(string deviceId, string[] args, out string stdout)
+    {
+        // Trust pm's own exit code: 0 means it ran (an empty list is valid). Under root adbd pm exits non-zero.
+        if (ADBService.ExecuteDeviceAdbShellCommand(deviceId, "pm", out stdout, out _, CancellationToken.None, args) == 0)
+            return true;
+
+        foreach (var output in ADBService.ShellUserFallbackAttempts(deviceId, $"pm {string.Join(' ', args)}"))
+        {
+            // A binder error line ("Failure calling service package:") also contains "package:" - exclude it.
+            if (!ADBService.IsBinderShellFailure(output) && output.Contains("package:"))
+            {
+                stdout = output;
+                return true;
+            }
+        }
+
+        stdout = "";
+        return false;
     }
 
     public static void ChangeDateFromName(LogicalDeviceViewModel device, IEnumerable<FileClass> items, Dispatcher dispatcher)

--- a/ADB Explorer/Services/ThumbnailService.cs
+++ b/ADB Explorer/Services/ThumbnailService.cs
@@ -769,14 +769,27 @@ public static partial class ThumbnailService
 
     private static string GetThumbsFromDevice(DeviceThumbnailInfo info, MediaType media, CancellationToken cancellationToken)
     {
+        var projection = $"_id:_data:resolution:{(media is MediaType.images ? "f_number:iso:exposure_time" : "duration:bitrate")}";
+        var uri = $"content://media/external/{media}/media";
+
         ADBService.ExecuteDeviceAdbShellCommand(
                     info.PhysicalId, "content",
                     out string stdout, out _,
                     cancellationToken,
                     "query",
-                    "--uri", $"content://media/external/{media}/media",
-                    "--projection", $"_id:_data:resolution:{(media is MediaType.images ? "f_number:iso:exposure_time" : "duration:bitrate")}"
+                    "--uri", uri,
+                    "--projection", projection
                 );
+
+        // content is a binder command; root adbd rejects it. Retry as the shell user so thumbnails still load.
+        if (ADBService.IsBinderShellFailure(stdout))
+        {
+            foreach (var output in ADBService.ShellUserFallbackAttempts(info.PhysicalId, $"content query --uri {uri} --projection {projection}"))
+            {
+                if (!ADBService.IsBinderShellFailure(output))
+                    return output;
+            }
+        }
 
         return stdout;
     }

--- a/ADB Explorer/Strings/Resources.Designer.cs
+++ b/ADB Explorer/Strings/Resources.Designer.cs
@@ -946,6 +946,15 @@ namespace ADB_Explorer.Strings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Location.
+        /// </summary>
+        public static string S_COLUMN_LOCATION {
+            get {
+                return ResourceManager.GetString("S_COLUMN_LOCATION", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Name.
         /// </summary>
         public static string S_COLUMN_NAME {
@@ -953,7 +962,7 @@ namespace ADB_Explorer.Strings {
                 return ResourceManager.GetString("S_COLUMN_NAME", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Operation Type.
         /// </summary>

--- a/ADB Explorer/Strings/Resources.resx
+++ b/ADB Explorer/Strings/Resources.resx
@@ -881,6 +881,10 @@ Cancel All Running</value>
     <value>Name</value>
     <comment>File browser data grid column name for the file name</comment>
   </data>
+  <data name="S_COLUMN_LOCATION" xml:space="preserve">
+    <value>Location</value>
+    <comment>File browser data grid column name for the parent folder of an item in recursive search results</comment>
+  </data>
   <data name="S_COLUMN_ORIGINAL_LOCATION" xml:space="preserve">
     <value>Original Location</value>
     <comment>File browser data grid column name for the original location of an item in the recycle bin</comment>

--- a/ADB Explorer/ViewModels/Device/DeviceViewModel.cs
+++ b/ADB Explorer/ViewModels/Device/DeviceViewModel.cs
@@ -127,7 +127,7 @@ public abstract class DeviceViewModel : ViewModelBase
 
             if (this is LogicalDeviceViewModel)
             {
-                ShellCommands.DeviceCommands.Remove(ID);
+                ShellCommands.DeviceCommands.TryRemove(ID, out _);
                 if (status is DeviceStatus.Ok)
                     Task.Run(() => ShellCommands.FindCommands(ID));
             }

--- a/ADB Explorer/ViewModels/Device/LogicalDeviceViewModel.cs
+++ b/ADB Explorer/ViewModels/Device/LogicalDeviceViewModel.cs
@@ -233,6 +233,9 @@ public partial class LogicalDeviceViewModel : DeviceViewModel
         }
     } = "";
 
+    /// <summary>Cached mount table, used to resolve per-path restrictions on the multi-mount root drive.</summary>
+    public IReadOnlyList<Models.FileSystemInfo> MountPoints { get; set; } = [];
+
     public HashSet<string> AdbFeatures
     {
         get
@@ -412,6 +415,7 @@ public partial class LogicalDeviceViewModel : DeviceViewModel
             Data.DirList?.RefreshLocationAccess();
 
         OnPropertyChanged(nameof(Root));
+        OnPropertyChanged(nameof(RootString));
     }
 
     public bool SetRootStatus(RootStatus status)

--- a/ADB Explorer/ViewModels/Drive/DriveViewModel.cs
+++ b/ADB Explorer/ViewModels/Drive/DriveViewModel.cs
@@ -25,7 +25,7 @@ public partial class DriveViewModel : AbstractDrive, IBrowserItem
 
     public new string DisplayName => Drive.DisplayName;
 
-    public DriveRestrictions Restrictions => DriveRestrictions.From(FSInfo?.Options);
+    public DriveRestrictions Restrictions => DriveRestrictions.From(FSInfo?.Options, FSInfo?.FileSystemType);
 
     public bool HasDriveRestrictions => Restrictions.HasAny;
 

--- a/ADB Explorer/ViewModels/Pages/ExplorerViewModel.cs
+++ b/ADB Explorer/ViewModels/Pages/ExplorerViewModel.cs
@@ -161,6 +161,9 @@ public partial class ExplorerViewModel : ObservableObject, INavigationAware
     public Visibility PackageColumnVisibility
         => Data.FileActions.IsAppDrive ? Visibility.Visible : Visibility.Collapsed;
 
+    public Visibility SearchColumnVisibility
+        => Data.FileActions.IsExplorerSearchResults ? Visibility.Visible : Visibility.Collapsed;
+
     public void NotifySelectedFilesTotalSize()
     {
         OnPropertyChanged(nameof(SelectedFilesTotalSize));
@@ -353,6 +356,10 @@ public partial class ExplorerViewModel : ObservableObject, INavigationAware
             case nameof(FileActionsEnable.ExplorerFilter):
                 _filterDebounceTimer.Stop();
                 _filterDebounceTimer.Start();
+                break;
+
+            case nameof(FileActionsEnable.IsExplorerSearchResults):
+                OnPropertyChanged(nameof(SearchColumnVisibility));
                 break;
 
             default:

--- a/ADB Explorer/Views/File/FileIconView.xaml
+++ b/ADB Explorer/Views/File/FileIconView.xaml
@@ -97,6 +97,7 @@
                                 KeyDown="IconViewNameEdit_KeyDown"
                                 Loaded="IconViewNameEdit_Loaded"
                                 LostFocus="IconViewNameEdit_LostFocus"
+                                Unloaded="IconViewNameEdit_Unloaded"
                                 Style="{StaticResource FileNameEditingElementStyle}"
                                 TextChanged="IconViewNameEdit_TextChanged"
                                 TextWrapping="Wrap" />

--- a/ADB Explorer/Views/File/FileIconView.xaml.cs
+++ b/ADB Explorer/Views/File/FileIconView.xaml.cs
@@ -107,6 +107,14 @@ public partial class FileIconView : UserControl
         RenameEnded?.Invoke(null, EventArgs.Empty);
     }
 
+    private void IconViewNameEdit_Unloaded(object sender, RoutedEventArgs e)
+    {
+        // Edit box removed for any reason (commit, virtualization, interrupted rename) - clear the editing
+        // flag so the shared rename tooltip, bound to it, can't stay stuck on screen.
+        if (FileActions.IsExplorerEditing)
+            FileActions.IsExplorerEditing = false;
+    }
+
     private void IconViewNameEdit_LostFocus(object sender, RoutedEventArgs e)
     {
         if (sender is not System.Windows.Controls.TextBox textBox)


### PR DESCRIPTION
Rooted devices
- Installed Apps and thumbnails now work when adbd is running as root (in that state pm/content get rejected, so they retry as the shell user).
- The root enable/disable toggle works reliably now — it was reporting "Forbidden" when root had actually enabled, and the status label wasn't updating after a toggle.
- Auto-root no longer fires in the middle of connecting (it was restarting adbd mid-setup and freezing the UI); it waits until the device is set up, and won't fire twice.


Startup / performance
- Fixed a UI freeze on connect when auto-open is enabled — opening the device was racing the capability probe. Also throttled some background polling that ran heavy work every half-second.  (still have some stutter on first launch with Auto Open Browse Option Enabled).


Drive / browsing
- The Root drive is no longer shown as fully read-only; writable mounts under it (like /data) are detected per-path.
- Added a recursive search (press Enter in the filter box to search the whole folder subtree).


Bug fixes
- Package count now respects the "show system apps" setting.
- A stuck rename tooltip, and the file-op popup vanishing too fast to read on small transfers.


Animations
- Animated Manual Device Refresh Button (arrow now spins)
